### PR TITLE
Support for non Maven centric version hint and case insensitive matching for branch prefixes

### DIFF
--- a/aurora-git-version/src/main/java/no/skatteetaten/aurora/version/SuggesterOptions.java
+++ b/aurora-git-version/src/main/java/no/skatteetaten/aurora/version/SuggesterOptions.java
@@ -50,7 +50,12 @@ public class SuggesterOptions {
     private List<String> branchesToUseTagsAsVersionsFor = emptyList();
 
     /**
-     * TODO: Document
+     * Version hint indicating current release track.
+     * Can contain non numeric information, as in 1.0-SNAPSHOT normally used by Maven.
+     * <p>
+     * Examples: <br>
+     *  1   - increment MINOR to next minor version for given major track 1.x
+     *  1.2 - increment PATCH to next patch version for given minor track 1.2.x
      */
     private String versionHint = null;
 

--- a/aurora-git-version/src/test/groovy/no/skatteetaten/aurora/version/suggest/ReleaseVersionEvaluatorTest.groovy
+++ b/aurora-git-version/src/test/groovy/no/skatteetaten/aurora/version/suggest/ReleaseVersionEvaluatorTest.groovy
@@ -17,10 +17,13 @@ class ReleaseVersionEvaluatorTest extends Specification {
       versionSegmentToIncrement == expectedVersionSegment
     where:
       expectedVersionSegment | versionHint
+      VersionSegment.PATCH   | "1.2.3"
       VersionSegment.PATCH   | "1.0.0-SNAPSHOT"
       VersionSegment.PATCH   | "1.0.1-SNAPSHOT"
+      VersionSegment.PATCH   | "1.2"
       VersionSegment.PATCH   | "1.0-SNAPSHOT"
       VersionSegment.PATCH   | "1.1-SNAPSHOT"
+      VersionSegment.MINOR   | "1"
       VersionSegment.MINOR   | "1-SNAPSHOT"
   }
 
@@ -44,6 +47,8 @@ class ReleaseVersionEvaluatorTest extends Specification {
       VersionSegment.MINOR   | "1.0.1-SNAPSHOT" | "feature/some"        | []                     | ["feature"]
       VersionSegment.MINOR   | "1.0-SNAPSHOT"   | "feature/some"        | ["feature"]            | ["feature"]
       VersionSegment.PATCH   | "1.0-SNAPSHOT"   | "bugfix/some"         | ["bugfix", "hotfix"]   | ["feature"]
+      VersionSegment.PATCH   | "1.0-SNAPSHOT"   | "bugfix/some"         | ["BUGFIX", "hotfix"]   | ["feature"]
+      VersionSegment.PATCH   | "1.0-SNAPSHOT"   | "BUGFIX/some"         | ["bugfix", "hotfix"]   | ["feature"]
 
   }
 

--- a/aurora-git-version/src/test/groovy/no/skatteetaten/aurora/version/suggest/ReleaseVersionIncrementerTest.groovy
+++ b/aurora-git-version/src/test/groovy/no/skatteetaten/aurora/version/suggest/ReleaseVersionIncrementerTest.groovy
@@ -21,6 +21,12 @@ class ReleaseVersionIncrementerTest extends Specification {
 
     where:
       expectedVersion | versionSegmentToIncrement | versionHint
+      "1.0.10"        | VersionSegment.PATCH      | "1.0.10" // start from a non existing version
+      "1.0.3"         | VersionSegment.PATCH      | "1.0.2"
+      "1.0.3"         | VersionSegment.PATCH      | "1.0"
+      "1.1.2"         | VersionSegment.PATCH      | "1.1"
+      "1.1.2"         | VersionSegment.PATCH      | "1.1.x"        // same as '1.1'
+      "1.1.2"         | VersionSegment.PATCH      | "1.1-SNAPSHOT" // same as '1.1'
       "1.0.3"         | VersionSegment.PATCH      | "1.0-SNAPSHOT"
       "1.1.2"         | VersionSegment.PATCH      | "1.1-SNAPSHOT"
       "1.2.3"         | VersionSegment.PATCH      | "1.2-SNAPSHOT"
@@ -30,6 +36,9 @@ class ReleaseVersionIncrementerTest extends Specification {
       "1.3.1"         | VersionSegment.PATCH      | "1-SNAPSHOT"
       "2.0.0"         | VersionSegment.PATCH      | "2-SNAPSHOT"
       "3.0.0"         | VersionSegment.PATCH      | "3-SNAPSHOT"
+      "1.4.0"         | VersionSegment.MINOR      | "1.2.2"
+      "1.2.10"        | VersionSegment.MINOR      | "1.2.10"
+      "1.5.10"        | VersionSegment.MINOR      | "1.5.10"
       "1.4.0"         | VersionSegment.MINOR      | "1.0-SNAPSHOT"
       "1.4.0"         | VersionSegment.MINOR      | "1.1-SNAPSHOT"
       "1.4.0"         | VersionSegment.MINOR      | "1.2-SNAPSHOT"

--- a/aurora-git-version/src/test/groovy/no/skatteetaten/aurora/version/suggest/ReleaseVersionTest.groovy
+++ b/aurora-git-version/src/test/groovy/no/skatteetaten/aurora/version/suggest/ReleaseVersionTest.groovy
@@ -31,6 +31,9 @@ class ReleaseVersionTest extends Specification {
 
     where:
       expectedVersion | versionHint
+      "1.1.2"         | "1.1.0"
+      "1.1.2"         | "1.1.1"
+      "1.1.2"         | "1.1"
       "1.0.0"         | "1.0-SNAPSHOT"
       "1.1.2"         | "1.1-SNAPSHOT"
       "1.4.0"         | "1.4-SNAPSHOT"


### PR DESCRIPTION
The non Maven centric version hint solution is a backwards compatible change. It ignores all non numeric information in the version hint. Meaning that "1.1" will give the same outcome as "1.1-SNAPSHOT" or "1.1.x"