### PR TITLE
Bugfix for wrong handling of major only version hints.

### DIFF
--- a/aurora-git-version/src/main/java/no/skatteetaten/aurora/version/suggest/ReleaseVersionEvaluator.java
+++ b/aurora-git-version/src/main/java/no/skatteetaten/aurora/version/suggest/ReleaseVersionEvaluator.java
@@ -15,11 +15,10 @@ public final class ReleaseVersionEvaluator {
      * <p>
      * If none of the forced update conditions apply, the number of version segments in the current
      * version hint will dictate which segment to increment. <br>
-     * All non numeric text is striped from the version hint, allowing version hint as 1.0-SNAPSHOT <br>
+     * <p>
      *   Examples:<br>
-     *     1.0          - Increment PATCH to next patch version<br>
-     *     1.0-SNAPSHOT - Increment PATCH to next patch version<br>
-     *     1            - Increment MINOR to next minor version<br>
+     *     1.0 - Increment PATCH to next patch version<br>
+     *     1   - Increment MINOR to next minor version<br>
      */
     public static VersionSegment findVersionSegmentToIncrement(
         String versionHintAsString,

--- a/aurora-git-version/src/main/java/no/skatteetaten/aurora/version/suggest/ReleaseVersionIncrementer.java
+++ b/aurora-git-version/src/main/java/no/skatteetaten/aurora/version/suggest/ReleaseVersionIncrementer.java
@@ -28,13 +28,13 @@ public final class ReleaseVersionIncrementer {
                 isVersionTagPartOfReleaseTrack(versionSegmentToIncrement, versionHint, versionTag))
             .reduce((first, second) -> second);
 
-        // First version tag in a new release track
+        // To handle first version tag in a new release track
         if (!latestTagInCurrentReleaseTrack.isPresent()) {
             return versionHint.unlockVersion();
         }
 
         // To handle version bumping within the same release track
-        if (isVersionHintGraterThanVersionTag(versionHint, latestTagInCurrentReleaseTrack.get())) {
+        if (isVersionHintGreaterThanVersionTag(versionHint, latestTagInCurrentReleaseTrack.get())) {
             return versionHint.unlockVersion();
         }
 
@@ -72,7 +72,7 @@ public final class ReleaseVersionIncrementer {
         return true;
     }
 
-    private static boolean isVersionHintGraterThanVersionTag(VersionNumber versionHint, VersionNumber versionTag) {
+    private static boolean isVersionHintGreaterThanVersionTag(VersionNumber versionHint, VersionNumber versionTag) {
         VersionNumber versionHintAsSemanticVersion = VersionNumber.parse(versionHint.unlockVersion().toString());
         return versionHintAsSemanticVersion.compareTo(versionTag) > 0;
     }

--- a/aurora-git-version/src/main/java/no/skatteetaten/aurora/version/suggest/ReleaseVersionIncrementer.java
+++ b/aurora-git-version/src/main/java/no/skatteetaten/aurora/version/suggest/ReleaseVersionIncrementer.java
@@ -2,7 +2,6 @@ package no.skatteetaten.aurora.version.suggest;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 public final class ReleaseVersionIncrementer {
 
@@ -17,47 +16,65 @@ public final class ReleaseVersionIncrementer {
      */
     public static VersionNumber suggestNextReleaseVersion(
         VersionSegment versionSegmentToIncrement,
-        String currentVersionAsString,
+        String versionHintAsString,
         List<String> existingVersions) {
 
-        VersionNumber versionHint = VersionNumber.parseVersionHint(currentVersionAsString);
+        VersionNumber versionHint = VersionNumber.parseVersionHint(versionHintAsString);
 
-        List<VersionNumber> orderedListOfVersions = existingVersions.stream()
+        Optional<VersionNumber> latestTagInCurrentReleaseTrack = existingVersions.stream()
             .map(VersionNumber::parse)
             .sorted()
-            .collect(Collectors.toList());
-
-        Optional<VersionNumber> eligibleVersion = orderedListOfVersions.stream()
-            .filter(versionHint::canBeUsedWhenDeterminingReleaseVersion)
+            .filter(versionTag ->
+                isVersionTagPartOfReleaseTrack(versionSegmentToIncrement, versionHint, versionTag))
             .reduce((first, second) -> second);
 
-        Optional<VersionNumber> lastRelease = orderedListOfVersions.stream()
-            .filter(VersionNumber::isSemanticVersion)
-            .reduce((first, second) -> second);
-
-        if (!eligibleVersion.isPresent()) {
+        // First version tag in a new release track
+        if (!latestTagInCurrentReleaseTrack.isPresent()) {
             return versionHint.unlockVersion();
         }
 
-        if (useVersionHintAsIs(versionHint, eligibleVersion.get())) {
+        // To handle version bumping within the same release track
+        if (isVersionHintGraterThanVersionTag(versionHint, latestTagInCurrentReleaseTrack.get())) {
             return versionHint.unlockVersion();
         }
 
         if (VersionSegment.MINOR.equals(versionSegmentToIncrement)) {
-            return lastRelease
-                .map(VersionNumber::incrementMinorSegment)
-                .orElse(versionHint.unlockVersion());
+            return latestTagInCurrentReleaseTrack.get().incrementMinorSegment();
+        } else {
+            return latestTagInCurrentReleaseTrack.get().incrementPatchSegment();
         }
-
-        return eligibleVersion.get().incrementPatchSegment();
     }
 
-    private static boolean useVersionHintAsIs(VersionNumber versionHint, VersionNumber eligibleVersion) {
-        if (versionHint.getVersionNumberSegments().size() != 3) {
+    private static boolean isVersionTagPartOfReleaseTrack(
+        VersionSegment versionSegment, VersionNumber versionHint, VersionNumber versionTag) {
+
+        if (!versionTag.isSemanticVersion()) {
             return false;
         }
-        VersionNumber versionHintAsSemanticVersion = VersionNumber.parse(versionHint.toString());
-        return versionHintAsSemanticVersion.compareTo(eligibleVersion) > 0;
+
+        List<String> versionTagSegments = versionTag.getVersionNumberSegments();
+        List<String> versionHintSegments = versionHint.getVersionNumberSegments();
+
+        int segmentsToCompare = VersionSegment.PATCH.equals(versionSegment) ? 2 : 1;
+        if (versionHintSegments.size() < segmentsToCompare) {
+            segmentsToCompare = versionHintSegments.size();
+        }
+
+        if (segmentsToCompare == 0) {
+            return false;
+        }
+        if (segmentsToCompare >= 1 && !versionHintSegments.get(0).equals(versionTagSegments.get(0))) {
+            return false;
+        }
+        if (segmentsToCompare >= 2 && !versionHintSegments.get(1).equals(versionTagSegments.get(1))) {
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean isVersionHintGraterThanVersionTag(VersionNumber versionHint, VersionNumber versionTag) {
+        VersionNumber versionHintAsSemanticVersion = VersionNumber.parse(versionHint.unlockVersion().toString());
+        return versionHintAsSemanticVersion.compareTo(versionTag) > 0;
     }
 
 }

--- a/aurora-git-version/src/main/java/no/skatteetaten/aurora/version/suggest/VersionNumber.java
+++ b/aurora-git-version/src/main/java/no/skatteetaten/aurora/version/suggest/VersionNumber.java
@@ -75,25 +75,6 @@ public final class VersionNumber implements Comparable<VersionNumber> {
         return new VersionNumber(versionNumberSegments.subList(0, newLength), isSemanticVersion);
     }
 
-    public boolean canBeUsedWhenDeterminingReleaseVersion(VersionNumber other) {
-        if (!other.isSemanticVersion || this.isSemanticVersion) {
-            return false;
-        }
-        if (other.versionNumberSegments.size() > this.versionNumberSegments.size()) {
-            other = other.shorten(versionNumberSegments.size());
-        }
-
-        List<String> thisSegs = this.versionNumberSegments;
-        List<String> otherSegs = other.versionNumberSegments;
-        if (thisSegs.size() >= 1 && !thisSegs.get(0).equals(otherSegs.get(0))) {
-            return false;
-        }
-        if (thisSegs.size() >= 2 && !thisSegs.get(1).equals(otherSegs.get(1))) {
-            return false;
-        }
-        return true;
-    }
-
     public VersionNumber unlockVersion() {
 
         List<String> segments = new ArrayList<>(versionNumberSegments);

--- a/aurora-git-version/src/test/groovy/no/skatteetaten/aurora/version/suggest/ReleaseVersionEvaluatorTest.groovy
+++ b/aurora-git-version/src/test/groovy/no/skatteetaten/aurora/version/suggest/ReleaseVersionEvaluatorTest.groovy
@@ -18,13 +18,12 @@ class ReleaseVersionEvaluatorTest extends Specification {
     where:
       expectedVersionSegment | versionHint
       VersionSegment.PATCH   | "1.2.3"
-      VersionSegment.PATCH   | "1.0.0-SNAPSHOT"
-      VersionSegment.PATCH   | "1.0.1-SNAPSHOT"
+      VersionSegment.PATCH   | "1.0.0"
+      VersionSegment.PATCH   | "1.0.1"
       VersionSegment.PATCH   | "1.2"
-      VersionSegment.PATCH   | "1.0-SNAPSHOT"
-      VersionSegment.PATCH   | "1.1-SNAPSHOT"
+      VersionSegment.PATCH   | "1.0"
+      VersionSegment.PATCH   | "1.1"
       VersionSegment.MINOR   | "1"
-      VersionSegment.MINOR   | "1-SNAPSHOT"
   }
 
   @Unroll
@@ -38,17 +37,17 @@ class ReleaseVersionEvaluatorTest extends Specification {
     then:
       versionSegmentToIncrement == expectedVersionSegment
     where:
-      expectedVersionSegment | versionHint      | originatingBranchName | forcePatchIncrementFor | forceMinorIncrementFor
-      VersionSegment.PATCH   | "1-SNAPSHOT"     | "feature/some"        | ["feature"]            | []
-      VersionSegment.MINOR   | "1-SNAPSHOT"     | "feature/some"        | []                     | ["feature"]
-      VersionSegment.PATCH   | "1.0-SNAPSHOT"   | "feature/some"        | ["feature"]            | []
-      VersionSegment.MINOR   | "1.0-SNAPSHOT"   | "feature/some"        | []                     | ["feature"]
-      VersionSegment.PATCH   | "1.0.1-SNAPSHOT" | "feature/some"        | ["feature"]            | []
-      VersionSegment.MINOR   | "1.0.1-SNAPSHOT" | "feature/some"        | []                     | ["feature"]
-      VersionSegment.MINOR   | "1.0-SNAPSHOT"   | "feature/some"        | ["feature"]            | ["feature"]
-      VersionSegment.PATCH   | "1.0-SNAPSHOT"   | "bugfix/some"         | ["bugfix", "hotfix"]   | ["feature"]
-      VersionSegment.PATCH   | "1.0-SNAPSHOT"   | "bugfix/some"         | ["BUGFIX", "hotfix"]   | ["feature"]
-      VersionSegment.PATCH   | "1.0-SNAPSHOT"   | "BUGFIX/some"         | ["bugfix", "hotfix"]   | ["feature"]
+      expectedVersionSegment | versionHint | originatingBranchName | forcePatchIncrementFor | forceMinorIncrementFor
+      VersionSegment.PATCH   | "1"         | "feature/some"        | ["feature"]            | []
+      VersionSegment.MINOR   | "1"         | "feature/some"        | []                     | ["feature"]
+      VersionSegment.PATCH   | "1.0"       | "feature/some"        | ["feature"]            | []
+      VersionSegment.MINOR   | "1.0"       | "feature/some"        | []                     | ["feature"]
+      VersionSegment.PATCH   | "1.0.1"     | "feature/some"        | ["feature"]            | []
+      VersionSegment.MINOR   | "1.0.1"     | "feature/some"        | []                     | ["feature"]
+      VersionSegment.MINOR   | "1.0"       | "feature/some"        | ["feature"]            | ["feature"]
+      VersionSegment.PATCH   | "1.0"       | "bugfix/some"         | ["bugfix", "hotfix"]   | ["feature"]
+      VersionSegment.PATCH   | "1.0"       | "bugfix/some"         | ["BUGFIX", "hotfix"]   | ["feature"]
+      VersionSegment.PATCH   | "1.0"       | "BUGFIX/some"         | ["bugfix", "hotfix"]   | ["feature"]
 
   }
 

--- a/aurora-git-version/src/test/groovy/no/skatteetaten/aurora/version/suggest/ReleaseVersionIncrementerTest.groovy
+++ b/aurora-git-version/src/test/groovy/no/skatteetaten/aurora/version/suggest/ReleaseVersionIncrementerTest.groovy
@@ -8,8 +8,8 @@ class ReleaseVersionIncrementerTest extends Specification {
   @Unroll
   def "shall suggest version #expectedVersion for segment #versionSegmentToIncrement and version #versionHint"() {
     given:
-      def existingVersions = ["2.1.2", "2.3.3", "3.0.0", "1.0.0", "1.0.1", "1.0.2", "1.1.2-SNAPSHOT",
-                              "1.1.1", "1.1.0", "1.2.0", "1.2.1", "1.2.2", "1.2.3-SNAPSHOT", "1.3.0"]
+      def existingVersions = ["2.1.2", "2.3.3", "3.0.0", "1.0.0", "1.0.1", "1.0.2",
+                              "1.1.1", "1.1.0", "1.2.0", "1.2.1", "1.2.2", "1.3.0"]
 
     when:
       def inferredVersion = ReleaseVersionIncrementer.suggestNextReleaseVersion(
@@ -26,35 +26,33 @@ class ReleaseVersionIncrementerTest extends Specification {
       "1.0.3"         | VersionSegment.PATCH      | "1.0.2"
       "1.0.3"         | VersionSegment.PATCH      | "1.0"
       "1.1.2"         | VersionSegment.PATCH      | "1.1"
-      "1.1.2"         | VersionSegment.PATCH      | "1.1.x"        // same as '1.1'
-      "1.1.2"         | VersionSegment.PATCH      | "1.1-SNAPSHOT" // same as '1.1'
-      "1.0.3"         | VersionSegment.PATCH      | "1.0-SNAPSHOT"
-      "1.1.2"         | VersionSegment.PATCH      | "1.1-SNAPSHOT"
-      "1.2.3"         | VersionSegment.PATCH      | "1.2-SNAPSHOT"
-      "1.3.1"         | VersionSegment.PATCH      | "1.3-SNAPSHOT"
-      "1.4.0"         | VersionSegment.PATCH      | "1.4-SNAPSHOT"
-      "1.5.0"         | VersionSegment.PATCH      | "1.5-SNAPSHOT"
-      "1.3.1"         | VersionSegment.PATCH      | "1-SNAPSHOT"
-      "2.3.4"         | VersionSegment.PATCH      | "2-SNAPSHOT"
-      "3.0.1"         | VersionSegment.PATCH      | "3-SNAPSHOT"
-      "4.0.0"         | VersionSegment.PATCH      | "4-SNAPSHOT"
+      "1.0.3"         | VersionSegment.PATCH      | "1.0"
+      "1.1.2"         | VersionSegment.PATCH      | "1.1"
+      "1.2.3"         | VersionSegment.PATCH      | "1.2"
+      "1.3.1"         | VersionSegment.PATCH      | "1.3"
+      "1.4.0"         | VersionSegment.PATCH      | "1.4"
+      "1.5.0"         | VersionSegment.PATCH      | "1.5"
+      "1.3.1"         | VersionSegment.PATCH      | "1"
+      "2.3.4"         | VersionSegment.PATCH      | "2"
+      "3.0.1"         | VersionSegment.PATCH      | "3"
+      "4.0.0"         | VersionSegment.PATCH      | "4"
       "1.4.0"         | VersionSegment.MINOR      | "1.2.2"
       "1.4.0"         | VersionSegment.MINOR      | "1.2.10"
       "1.5.10"        | VersionSegment.MINOR      | "1.5.10"
-      "1.4.0"         | VersionSegment.MINOR      | "1.0-SNAPSHOT"
-      "1.4.0"         | VersionSegment.MINOR      | "1.1-SNAPSHOT"
-      "1.4.0"         | VersionSegment.MINOR      | "1.2-SNAPSHOT"
-      "1.4.0"         | VersionSegment.MINOR      | "1.3-SNAPSHOT"
-      "1.4.0"         | VersionSegment.MINOR      | "1.4-SNAPSHOT"
-      "1.5.0"         | VersionSegment.MINOR      | "1.5-SNAPSHOT"
-      "1.4.0"         | VersionSegment.MINOR      | "1-SNAPSHOT"
-      "1.4.0"         | VersionSegment.MINOR      | "1.2-SNAPSHOT"
-      "2.4.0"         | VersionSegment.MINOR      | "2-SNAPSHOT"
-      "2.4.0"         | VersionSegment.MINOR      | "2.2-SNAPSHOT"
-      "3.1.0"         | VersionSegment.MINOR      | "3-SNAPSHOT"
-      "3.1.0"         | VersionSegment.MINOR      | "3.0-SNAPSHOT"
-      "4.0.0"         | VersionSegment.MINOR      | "4-SNAPSHOT"
-      "4.0.0"         | VersionSegment.MINOR      | "4.0-SNAPSHOT"
+      "1.4.0"         | VersionSegment.MINOR      | "1.0"
+      "1.4.0"         | VersionSegment.MINOR      | "1.1"
+      "1.4.0"         | VersionSegment.MINOR      | "1.2"
+      "1.4.0"         | VersionSegment.MINOR      | "1.3"
+      "1.4.0"         | VersionSegment.MINOR      | "1.4"
+      "1.5.0"         | VersionSegment.MINOR      | "1.5"
+      "1.4.0"         | VersionSegment.MINOR      | "1"
+      "1.4.0"         | VersionSegment.MINOR      | "1.2"
+      "2.4.0"         | VersionSegment.MINOR      | "2"
+      "2.4.0"         | VersionSegment.MINOR      | "2.2"
+      "3.1.0"         | VersionSegment.MINOR      | "3"
+      "3.1.0"         | VersionSegment.MINOR      | "3.0"
+      "4.0.0"         | VersionSegment.MINOR      | "4"
+      "4.0.0"         | VersionSegment.MINOR      | "4.0"
   }
 
   @Unroll
@@ -73,23 +71,38 @@ class ReleaseVersionIncrementerTest extends Specification {
 
     where:
       expectedVersion | versionSegmentToIncrement | versionHint
-      "0.0.0"         | VersionSegment.PATCH      | "0-SNAPSHOT"
-      "0.0.0"         | VersionSegment.PATCH      | "0.0-SNAPSHOT"
-      "1.0.0"         | VersionSegment.PATCH      | "1-SNAPSHOT"
-      "4.0.0"         | VersionSegment.PATCH      | "4-SNAPSHOT"
-      "1.0.0"         | VersionSegment.PATCH      | "1.0-SNAPSHOT"
-      "1.4.0"         | VersionSegment.PATCH      | "1.4-SNAPSHOT"
-      "1.1.1"         | VersionSegment.PATCH      | "1.1.1-SNAPSHOT"
-      "1.4.4"         | VersionSegment.PATCH      | "1.4.4-SNAPSHOT"
-      "0.0.0"         | VersionSegment.MINOR      | "0-SNAPSHOT"
-      "1.0.0"         | VersionSegment.MINOR      | "1-SNAPSHOT"
-      "0.0.0"         | VersionSegment.MINOR      | "0.0-SNAPSHOT"
-      "1.0.0"         | VersionSegment.MINOR      | "1-SNAPSHOT"
-      "4.0.0"         | VersionSegment.MINOR      | "4-SNAPSHOT"
-      "1.0.0"         | VersionSegment.MINOR      | "1.0-SNAPSHOT"
-      "1.4.0"         | VersionSegment.MINOR      | "1.4-SNAPSHOT"
-      "1.1.1"         | VersionSegment.MINOR      | "1.1.1-SNAPSHOT"
-      "1.4.4"         | VersionSegment.MINOR      | "1.4.4-SNAPSHOT"
+      "0.0.0"         | VersionSegment.PATCH      | "0"
+      "0.0.0"         | VersionSegment.PATCH      | "0.0"
+      "1.0.0"         | VersionSegment.PATCH      | "1"
+      "4.0.0"         | VersionSegment.PATCH      | "4"
+      "1.0.0"         | VersionSegment.PATCH      | "1.0"
+      "1.4.0"         | VersionSegment.PATCH      | "1.4"
+      "1.1.1"         | VersionSegment.PATCH      | "1.1.1"
+      "1.4.4"         | VersionSegment.PATCH      | "1.4.4"
+      "0.0.0"         | VersionSegment.MINOR      | "0"
+      "1.0.0"         | VersionSegment.MINOR      | "1"
+      "0.0.0"         | VersionSegment.MINOR      | "0.0"
+      "1.0.0"         | VersionSegment.MINOR      | "1"
+      "4.0.0"         | VersionSegment.MINOR      | "4"
+      "1.0.0"         | VersionSegment.MINOR      | "1.0"
+      "1.4.0"         | VersionSegment.MINOR      | "1.4"
+      "1.1.1"         | VersionSegment.MINOR      | "1.1.1"
+      "1.4.4"         | VersionSegment.MINOR      | "1.4.4"
+  }
+
+  def "shall ignore non semantic version tags when determining which version number to suggest"() {
+    given:
+      def existingVersions = ["1.1", "1.0.0", "1.1.0.202", "1.1.0.ad4ea2f35", "1.1.0-SNAPSHOT"]
+      def versionHint = "1"
+
+    when:
+      def inferredVersion = ReleaseVersionIncrementer.suggestNextReleaseVersion(
+          VersionSegment.MINOR,
+          versionHint,
+          existingVersions)
+
+    then:
+      inferredVersion.toString() == "1.1.0"
 
   }
 

--- a/aurora-git-version/src/test/groovy/no/skatteetaten/aurora/version/suggest/ReleaseVersionIncrementerTest.groovy
+++ b/aurora-git-version/src/test/groovy/no/skatteetaten/aurora/version/suggest/ReleaseVersionIncrementerTest.groovy
@@ -8,7 +8,8 @@ class ReleaseVersionIncrementerTest extends Specification {
   @Unroll
   def "shall suggest version #expectedVersion for segment #versionSegmentToIncrement and version #versionHint"() {
     given:
-      def existingVersions = ["1.0.0", "1.0.1", "1.0.2", "1.1.2-SNAPSHOT", "1.1.1", "1.1.0", "1.2.0", "1.2.1", "1.2.2", "1.2.3-SNAPSHOT", "1.3.0"]
+      def existingVersions = ["2.1.2", "2.3.3", "3.0.0", "1.0.0", "1.0.1", "1.0.2", "1.1.2-SNAPSHOT",
+                              "1.1.1", "1.1.0", "1.2.0", "1.2.1", "1.2.2", "1.2.3-SNAPSHOT", "1.3.0"]
 
     when:
       def inferredVersion = ReleaseVersionIncrementer.suggestNextReleaseVersion(
@@ -34,10 +35,11 @@ class ReleaseVersionIncrementerTest extends Specification {
       "1.4.0"         | VersionSegment.PATCH      | "1.4-SNAPSHOT"
       "1.5.0"         | VersionSegment.PATCH      | "1.5-SNAPSHOT"
       "1.3.1"         | VersionSegment.PATCH      | "1-SNAPSHOT"
-      "2.0.0"         | VersionSegment.PATCH      | "2-SNAPSHOT"
-      "3.0.0"         | VersionSegment.PATCH      | "3-SNAPSHOT"
+      "2.3.4"         | VersionSegment.PATCH      | "2-SNAPSHOT"
+      "3.0.1"         | VersionSegment.PATCH      | "3-SNAPSHOT"
+      "4.0.0"         | VersionSegment.PATCH      | "4-SNAPSHOT"
       "1.4.0"         | VersionSegment.MINOR      | "1.2.2"
-      "1.2.10"        | VersionSegment.MINOR      | "1.2.10"
+      "1.4.0"         | VersionSegment.MINOR      | "1.2.10"
       "1.5.10"        | VersionSegment.MINOR      | "1.5.10"
       "1.4.0"         | VersionSegment.MINOR      | "1.0-SNAPSHOT"
       "1.4.0"         | VersionSegment.MINOR      | "1.1-SNAPSHOT"
@@ -46,9 +48,13 @@ class ReleaseVersionIncrementerTest extends Specification {
       "1.4.0"         | VersionSegment.MINOR      | "1.4-SNAPSHOT"
       "1.5.0"         | VersionSegment.MINOR      | "1.5-SNAPSHOT"
       "1.4.0"         | VersionSegment.MINOR      | "1-SNAPSHOT"
-      "2.0.0"         | VersionSegment.MINOR      | "2-SNAPSHOT"
-      "3.0.0"         | VersionSegment.MINOR      | "3-SNAPSHOT"
-
+      "1.4.0"         | VersionSegment.MINOR      | "1.2-SNAPSHOT"
+      "2.4.0"         | VersionSegment.MINOR      | "2-SNAPSHOT"
+      "2.4.0"         | VersionSegment.MINOR      | "2.2-SNAPSHOT"
+      "3.1.0"         | VersionSegment.MINOR      | "3-SNAPSHOT"
+      "3.1.0"         | VersionSegment.MINOR      | "3.0-SNAPSHOT"
+      "4.0.0"         | VersionSegment.MINOR      | "4-SNAPSHOT"
+      "4.0.0"         | VersionSegment.MINOR      | "4.0-SNAPSHOT"
   }
 
   @Unroll
@@ -76,6 +82,7 @@ class ReleaseVersionIncrementerTest extends Specification {
       "1.1.1"         | VersionSegment.PATCH      | "1.1.1-SNAPSHOT"
       "1.4.4"         | VersionSegment.PATCH      | "1.4.4-SNAPSHOT"
       "0.0.0"         | VersionSegment.MINOR      | "0-SNAPSHOT"
+      "1.0.0"         | VersionSegment.MINOR      | "1-SNAPSHOT"
       "0.0.0"         | VersionSegment.MINOR      | "0.0-SNAPSHOT"
       "1.0.0"         | VersionSegment.MINOR      | "1-SNAPSHOT"
       "4.0.0"         | VersionSegment.MINOR      | "4-SNAPSHOT"

--- a/aurora-git-version/src/test/groovy/no/skatteetaten/aurora/version/suggest/ReleaseVersionTest.groovy
+++ b/aurora-git-version/src/test/groovy/no/skatteetaten/aurora/version/suggest/ReleaseVersionTest.groovy
@@ -12,7 +12,7 @@ class ReleaseVersionTest extends Specification {
   @Unroll
   def "shall suggest version #expectedVersion for version #versionHint"() {
     given:
-      def existingVersions = ["1.1.0", "1.1.1", "1.1.2-SNAPSHOT", "1.2.2", "1.2.1", "1.2.0", "1.3.0"]
+      def existingVersions = ["2.2.2", "3.0.0", "1.1.0", "1.1.1", "1.1.2-SNAPSHOT", "1.2.2", "1.2.1", "1.2.0", "1.3.0"]
 
     when:
       def versionSegmentToIncrement = ReleaseVersionEvaluator.findVersionSegmentToIncrement(
@@ -38,13 +38,15 @@ class ReleaseVersionTest extends Specification {
       "1.1.2"         | "1.1-SNAPSHOT"
       "1.4.0"         | "1.4-SNAPSHOT"
       "1.4.0"         | "1-SNAPSHOT"
-      "2.0.0"         | "2-SNAPSHOT"
+      "2.3.0"         | "2"
+      "3.1.0"         | "3"
+      "4.0.0"         | "4"
   }
 
   @Unroll
   def "shall suggest version #expectedVersion for version #versionHint for #originatingBranchName, #forcePatchIncrementFor and #forceMinorIncrementFor"() {
     given:
-      def existingVersions = ["1.1.0", "1.1.1", "1.1.2-SNAPSHOT", "1.2.2", "1.2.1", "1.2.0", "1.3.0"]
+      def existingVersions = ["2.2.2", "3.0.0", "1.1.0", "1.1.1", "1.1.2-SNAPSHOT", "1.2.2", "1.2.1", "1.2.0", "1.3.0"]
 
     when:
       def versionSegmentToIncrement = ReleaseVersionEvaluator.findVersionSegmentToIncrement(
@@ -63,14 +65,18 @@ class ReleaseVersionTest extends Specification {
 
     where:
       expectedVersion | versionHint    | originatingBranchName | forcePatchIncrementFor | forceMinorIncrementFor
-      "1.1.2"         | "1.1-SNAPSHOT" | "feature/some"        | ["feature"]            | []
-      "1.4.0"         | "1.1-SNAPSHOT" | "feature/some"        | []                     | ["feature"]
-      "1.5.0"         | "1.5-SNAPSHOT" | "feature/some"        | ["feature"]            | []
-      "1.5.0"         | "1.5-SNAPSHOT" | "feature/some"        | []                     | ["feature"]
-      "1.3.1"         | "1-SNAPSHOT"   | "feature/some"        | ["feature"]            | []
-      "1.4.0"         | "1-SNAPSHOT"   | "feature/some"        | []                     | ["feature"]
-      "2.0.0"         | "2-SNAPSHOT"   | "feature/some"        | ["feature"]            | []
-      "2.0.0"         | "2-SNAPSHOT"   | "feature/some"        | []                     | ["feature"]
+      "1.1.2"         | "1.1-SNAPSHOT" | "branch/some"         | ["branch"]             | []
+      "1.4.0"         | "1.1-SNAPSHOT" | "branch/some"         | []                     | ["branch"]
+      "1.5.0"         | "1.5-SNAPSHOT" | "branch/some"         | ["branch"]             | []
+      "1.5.0"         | "1.5-SNAPSHOT" | "branch/some"         | []                     | ["branch"]
+      "1.3.1"         | "1-SNAPSHOT"   | "branch/some"         | ["branch"]             | []
+      "1.4.0"         | "1-SNAPSHOT"   | "branch/some"         | []                     | ["branch"]
+      "2.2.3"         | "2-SNAPSHOT"   | "branch/some"         | ["branch"]             | []
+      "2.3.0"         | "2-SNAPSHOT"   | "branch/some"         | []                     | ["branch"]
+      "3.0.1"         | "3-SNAPSHOT"   | "branch/some"         | ["branch"]             | []
+      "3.1.0"         | "3-SNAPSHOT"   | "branch/some"         | []                     | ["branch"]
+      "4.0.0"         | "4-SNAPSHOT"   | "branch/some"         | ["branch"]             | []
+      "4.0.0"         | "4-SNAPSHOT"   | "branch/some"         | []                     | ["branch"]
 
   }
 

--- a/aurora-git-version/src/test/groovy/no/skatteetaten/aurora/version/suggest/ReleaseVersionTest.groovy
+++ b/aurora-git-version/src/test/groovy/no/skatteetaten/aurora/version/suggest/ReleaseVersionTest.groovy
@@ -12,7 +12,7 @@ class ReleaseVersionTest extends Specification {
   @Unroll
   def "shall suggest version #expectedVersion for version #versionHint"() {
     given:
-      def existingVersions = ["2.2.2", "3.0.0", "1.1.0", "1.1.1", "1.1.2-SNAPSHOT", "1.2.2", "1.2.1", "1.2.0", "1.3.0"]
+      def existingVersions = ["2.2.2", "3.0.0", "1.1.0", "1.1.1", "1.2.2", "1.2.1", "1.2.0", "1.3.0"]
 
     when:
       def versionSegmentToIncrement = ReleaseVersionEvaluator.findVersionSegmentToIncrement(
@@ -34,10 +34,10 @@ class ReleaseVersionTest extends Specification {
       "1.1.2"         | "1.1.0"
       "1.1.2"         | "1.1.1"
       "1.1.2"         | "1.1"
-      "1.0.0"         | "1.0-SNAPSHOT"
-      "1.1.2"         | "1.1-SNAPSHOT"
-      "1.4.0"         | "1.4-SNAPSHOT"
-      "1.4.0"         | "1-SNAPSHOT"
+      "1.0.0"         | "1.0"
+      "1.1.2"         | "1.1"
+      "1.4.0"         | "1.4"
+      "1.4.0"         | "1"
       "2.3.0"         | "2"
       "3.1.0"         | "3"
       "4.0.0"         | "4"
@@ -46,7 +46,7 @@ class ReleaseVersionTest extends Specification {
   @Unroll
   def "shall suggest version #expectedVersion for version #versionHint for #originatingBranchName, #forcePatchIncrementFor and #forceMinorIncrementFor"() {
     given:
-      def existingVersions = ["2.2.2", "3.0.0", "1.1.0", "1.1.1", "1.1.2-SNAPSHOT", "1.2.2", "1.2.1", "1.2.0", "1.3.0"]
+      def existingVersions = ["2.2.2", "3.0.0", "1.1.0", "1.1.1", "1.2.2", "1.2.1", "1.2.0", "1.3.0"]
 
     when:
       def versionSegmentToIncrement = ReleaseVersionEvaluator.findVersionSegmentToIncrement(
@@ -64,19 +64,19 @@ class ReleaseVersionTest extends Specification {
       inferredVersion.toString() == expectedVersion
 
     where:
-      expectedVersion | versionHint    | originatingBranchName | forcePatchIncrementFor | forceMinorIncrementFor
-      "1.1.2"         | "1.1-SNAPSHOT" | "branch/some"         | ["branch"]             | []
-      "1.4.0"         | "1.1-SNAPSHOT" | "branch/some"         | []                     | ["branch"]
-      "1.5.0"         | "1.5-SNAPSHOT" | "branch/some"         | ["branch"]             | []
-      "1.5.0"         | "1.5-SNAPSHOT" | "branch/some"         | []                     | ["branch"]
-      "1.3.1"         | "1-SNAPSHOT"   | "branch/some"         | ["branch"]             | []
-      "1.4.0"         | "1-SNAPSHOT"   | "branch/some"         | []                     | ["branch"]
-      "2.2.3"         | "2-SNAPSHOT"   | "branch/some"         | ["branch"]             | []
-      "2.3.0"         | "2-SNAPSHOT"   | "branch/some"         | []                     | ["branch"]
-      "3.0.1"         | "3-SNAPSHOT"   | "branch/some"         | ["branch"]             | []
-      "3.1.0"         | "3-SNAPSHOT"   | "branch/some"         | []                     | ["branch"]
-      "4.0.0"         | "4-SNAPSHOT"   | "branch/some"         | ["branch"]             | []
-      "4.0.0"         | "4-SNAPSHOT"   | "branch/some"         | []                     | ["branch"]
+      expectedVersion | versionHint | originatingBranchName | forcePatchIncrementFor | forceMinorIncrementFor
+      "1.1.2"         | "1.1"       | "branch/some"         | ["branch"]             | []
+      "1.4.0"         | "1.1"       | "branch/some"         | []                     | ["branch"]
+      "1.5.0"         | "1.5"       | "branch/some"         | ["branch"]             | []
+      "1.5.0"         | "1.5"       | "branch/some"         | []                     | ["branch"]
+      "1.3.1"         | "1"         | "branch/some"         | ["branch"]             | []
+      "1.4.0"         | "1"         | "branch/some"         | []                     | ["branch"]
+      "2.2.3"         | "2"         | "branch/some"         | ["branch"]             | []
+      "2.3.0"         | "2"         | "branch/some"         | []                     | ["branch"]
+      "3.0.1"         | "3"         | "branch/some"         | ["branch"]             | []
+      "3.1.0"         | "3"         | "branch/some"         | []                     | ["branch"]
+      "4.0.0"         | "4"         | "branch/some"         | ["branch"]             | []
+      "4.0.0"         | "4"         | "branch/some"         | []                     | ["branch"]
 
   }
 

--- a/aurora-git-version/src/test/groovy/no/skatteetaten/aurora/version/suggest/VersionNumberTest.groovy
+++ b/aurora-git-version/src/test/groovy/no/skatteetaten/aurora/version/suggest/VersionNumberTest.groovy
@@ -85,16 +85,6 @@ class VersionNumberTest extends Specification {
       shortenedVerison.toString() == "3.3"
   }
 
-  def "A version number with the same leading version numbers can be used when determining release version"() {
-    given:
-      def releasedVersion = VersionNumber.parse("3.3.1");
-      def developmentVersion = VersionNumber.parse("3.3-SNAPSHOT");
-    when:
-      def similar = developmentVersion.canBeUsedWhenDeterminingReleaseVersion(releasedVersion);
-    then:
-      similar == true
-  }
-
   def "Shorter version numbers autopads length when adapting to longer version number"() {
     given:
       def releasedVersion = VersionNumber.parse("3.4.0");

--- a/aurora-git-version/src/test/groovy/no/skatteetaten/aurora/version/suggest/VersionNumberTest.groovy
+++ b/aurora-git-version/src/test/groovy/no/skatteetaten/aurora/version/suggest/VersionNumberTest.groovy
@@ -4,12 +4,13 @@ import spock.lang.Specification
 
 class VersionNumberTest extends Specification {
 
-  def "version number with major, minor and revision versions outputs X.Y.Z"() {
+  def "version number with major, minor and patch is considered a semantic version"() {
     given:
       def version = "1.2.3"
     when:
       def versionNumber = VersionNumber.parse(version)
     then:
+      versionNumber.isSemanticVersion() == true
       versionNumber.toString() == "1.2.3"
   }
 
@@ -31,20 +32,28 @@ class VersionNumberTest extends Specification {
       versionNumber.toString() == "1234567.2345678.2322"
   }
 
-  def "Version number support Maven snapshot syntax"() {
-    given:
-      def version = "1.2-SNAPSHOT"
+  def "Various supported snapshot syntaxes"() {
     when:
-      def versionNumber = VersionNumber.parse(version)
+      def versionNumber = VersionNumber.parse(givenVersion)
+      def versionHint = VersionNumber.parseVersionHint(givenVersion)
     then:
       versionNumber.isSemanticVersion() == false
-      versionNumber.toString() == "1.2"
+      versionHint.isSemanticVersion() == false
+      versionNumber.toString() == expectedVersionString
+      versionHint.toString() == expectedVersionString
+    where:
+      givenVersion   | expectedVersionString
+      "1.2-SNAPSHOT" | "1.2"     // maven syntax
+      "1-SNAPSHOT"   | "1"       // maven syntax
+      "2.1.x"        | "2.1"
+      "2.x.x"        | "2"
   }
 
   def "Version numbers are naturally sorted by their individual segments"() {
     given:
       def unsortedVersions = [
-          VersionNumber.parse("8.2-SNAPSHOT"),
+          VersionNumber.parseVersionHint("8"),
+          VersionNumber.parseVersionHint("8.2"),
           VersionNumber.parse("8.2.8"),
           VersionNumber.parse("1.8.9"),
           VersionNumber.parse("8.2.0"),
@@ -52,32 +61,32 @@ class VersionNumberTest extends Specification {
     when:
       def sortedVersions = unsortedVersions.toSorted()
     then:
-      sortedVersions.collect { it.toString() } == ["1.8.9", "8.2.0", "8.2.8", "8.2", "10.0.1"]
+      sortedVersions.collect { it.toString() } == ["1.8.9", "8.2.0", "8.2.8", "8", "8.2", "10.0.1"]
   }
 
-  def "Snapshot versions are considered greater than equal release"() {
+  def "version hints are considered greater than equal semantic version"() {
     given:
       def baseVersion = VersionNumber.parse("3.3.0");
-      def snapshotVersion = VersionNumber.parse("3.3.0-SNAPSHOT");
+      def snapshotVersion = VersionNumber.parseVersionHint("3.3.0");
     when:
       def difference = baseVersion.compareTo(snapshotVersion);
     then:
       difference == -1
   }
 
-  def "Snapshot versions are considered greater than same version with more digits"() {
+  def "version hints are considered greater than same semantic version with more digits"() {
     given:
       def baseVersion = VersionNumber.parse("3.3.1");
-      def snapshotVersion = VersionNumber.parse("3.3-SNAPSHOT");
+      def snapshotVersion = VersionNumber.parseVersionHint("3.3");
     when:
       def difference = baseVersion.compareTo(snapshotVersion);
     then:
       difference == -1
   }
 
-  def "A shortened snapshot is still a snapshot"() {
+  def "A shortened non semantic version is still a non semantic version"() {
     given:
-      def originalVersion = VersionNumber.parse("3.3.1-SNAPSHOT");
+      def originalVersion = VersionNumber.parseVersionHint("3.3.1");
     when:
       def shortenedVerison = originalVersion.shorten(2);
     then:
@@ -88,7 +97,7 @@ class VersionNumberTest extends Specification {
   def "Shorter version numbers autopads length when adapting to longer version number"() {
     given:
       def releasedVersion = VersionNumber.parse("3.4.0");
-      def developmentVersion = VersionNumber.parse("3.4-SNAPSHOT");
+      def developmentVersion = VersionNumber.parseVersionHint("3.4");
     when:
       def adaptedVersion = releasedVersion.adaptTo(developmentVersion);
     then:
@@ -104,9 +113,9 @@ class VersionNumberTest extends Specification {
       increasedVersion.toString() == "3.2.2";
   }
 
-  def "last version number is incremented with snapshots"() {
+  def "last version number is incremented for non semantic versions"() {
     given:
-      def version = VersionNumber.parse("3.2-SNAPSHOT");
+      def version = VersionNumber.parseVersionHint("3.2");
     when:
       def increasedVersion = version.incrementPatchSegment();
     then:
@@ -114,17 +123,17 @@ class VersionNumberTest extends Specification {
       increasedVersion.isSemanticVersion() == false
   }
 
-  def "Version numbers is extended with another segment with value 0 when unlocked"() {
+  def "Version numbers are extended with segments with value 0 when unlocked"() {
     given:
-      def developmentVersion = VersionNumber.parse(version)
+      def developmentVersion = VersionNumber.parseVersionHint(givenVersion)
     when:
       def unlockedVersion = developmentVersion.unlockVersion()
     then:
       unlockedVersion.toString() == expectedVersion
     where:
-      version        | expectedVersion
-      "3.3-SNAPSHOT" | "3.3.0"
-      "3-SNAPSHOT"   | "3.0.0"
+      givenVersion | expectedVersion
+      "3.3"        | "3.3.0"
+      "3"          | "3.0.0"
   }
 
   def "Version hint is always treated as non semantic version"() {
@@ -138,9 +147,9 @@ class VersionNumberTest extends Specification {
       "1"              | "1"
       "1.1"            | "1.1"
       "1.0.1"          | "1.0.1"
-      "1-SNAPSHOT"     | "1"
-      "1.2-SNAPSHOT"   | "1.2"
-      "1.2.3-SNAPSHOT" | "1.2.3"
+      "1"              | "1"
+      "1.2"            | "1.2"
+      "1.2.3"          | "1.2.3"
   }
 
   def "example of valid semantic version numbers"() {
@@ -172,7 +181,7 @@ class VersionNumberTest extends Specification {
           "1..1.1..1",
           "123456789..123456789.123456789..123456789",
           "12.0.0.1",
-          "1.2-SNAPSHOT"
+          "1.2"
       ]
     when:
       def versionNumbers = versions.collect { VersionNumber.parse(it) }


### PR DESCRIPTION
For a given repository with two tags "v1.0.0" and "v2.0.0" and a version hint of "1", it would have suggested "v2.1.0" as the next version instead of "v1.1.0" as expected. This is now fixed, see test code for more details.